### PR TITLE
ci: only skip release when marker is on its own line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,11 @@ jobs:
         id: ver
         run: |
           msg=$(git log -1 --pretty=%B)
-          if echo "$msg" | grep -qiF '[skip release]'; then
+          # match only when [skip release] is on a line by itself, so a prose
+          # mention in the commit body doesn't accidentally skip the release.
+          if echo "$msg" | grep -qixF '[skip release]'; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "commit requests [skip release]; skipping"
+            echo "commit requests skip on its own line; skipping"
             exit 0
           fi
 


### PR DESCRIPTION
The previous skip check matched the marker as a substring anywhere in the commit message, so a prose mention in the body skipped the release (it happened on the #12 merge). Now matches the whole line via `grep -x`. Merging this should produce the first auto-bump, v0.12.1.